### PR TITLE
refactor: Post 조회 시 연관된 Comment, SubComment 정보도 응답에 포함하도록 수정 (#62)

### DIFF
--- a/src/main/java/com/codot/link/domains/auth/domain/RefreshToken.java
+++ b/src/main/java/com/codot/link/domains/auth/domain/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.codot.link.domains.auth.domain;
 
+import com.codot.link.common.auditing.BaseEntity;
 import com.codot.link.domains.user.domain.User;
 
 import jakarta.persistence.Column;
@@ -18,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @Entity
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken {
+public class RefreshToken extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/codot/link/domains/comment/domain/Comment.java
+++ b/src/main/java/com/codot/link/domains/comment/domain/Comment.java
@@ -3,6 +3,7 @@ package com.codot.link.domains.comment.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.codot.link.common.auditing.BaseEntity;
 import com.codot.link.domains.comment.dto.request.CommentCreateRequest;
 import com.codot.link.domains.comment.dto.request.CommentModifyRequest;
 import com.codot.link.domains.post.domain.Post;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+public class Comment extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/codot/link/domains/comment/domain/SubComment.java
+++ b/src/main/java/com/codot/link/domains/comment/domain/SubComment.java
@@ -1,5 +1,6 @@
 package com.codot.link.domains.comment.domain;
 
+import com.codot.link.common.auditing.BaseEntity;
 import com.codot.link.domains.comment.dto.request.SubCommentCreateRequest;
 import com.codot.link.domains.comment.dto.request.SubCommentModifyRequest;
 import com.codot.link.domains.user.domain.User;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SubComment {
+public class SubComment extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/codot/link/domains/group/domain/Group.java
+++ b/src/main/java/com/codot/link/domains/group/domain/Group.java
@@ -1,5 +1,6 @@
 package com.codot.link.domains.group.domain;
 
+import com.codot.link.common.auditing.BaseEntity;
 import com.codot.link.domains.group.dto.request.GroupCreateRequest;
 import com.codot.link.domains.group.dto.request.GroupModifyRequest;
 
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "groups")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Group {
+public class Group extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/codot/link/domains/group/domain/GroupUser.java
+++ b/src/main/java/com/codot/link/domains/group/domain/GroupUser.java
@@ -1,5 +1,6 @@
 package com.codot.link.domains.group.domain;
 
+import com.codot.link.common.auditing.BaseEntity;
 import com.codot.link.domains.user.domain.User;
 
 import jakarta.persistence.Column;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GroupUser {
+public class GroupUser extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/codot/link/domains/post/domain/Post.java
+++ b/src/main/java/com/codot/link/domains/post/domain/Post.java
@@ -3,6 +3,7 @@ package com.codot.link.domains.post.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.codot.link.common.auditing.BaseEntity;
 import com.codot.link.domains.comment.domain.Comment;
 import com.codot.link.domains.group.domain.Group;
 import com.codot.link.domains.post.dto.request.PostCreateRequest;
@@ -29,7 +30,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Post {
+public class Post extends BaseEntity {
 
 	@Id
 	@Column(name = "post_id")

--- a/src/main/java/com/codot/link/domains/post/dto/response/CommentResponse.java
+++ b/src/main/java/com/codot/link/domains/post/dto/response/CommentResponse.java
@@ -1,0 +1,56 @@
+package com.codot.link.domains.post.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.codot.link.domains.comment.domain.Comment;
+import com.codot.link.domains.user.domain.User;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CommentResponse {
+
+	private Long commentId;
+	private LocalDateTime createdAt;
+	private String content;
+	private Long writerId;
+	private String writerNickname;
+	private String writerFilePath;
+	private Integer subCommentCount;
+	private List<SubCommentResponse> subComments;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private CommentResponse(Long commentId, LocalDateTime createdAt, String content, Long writerId,
+		String writerNickname, String writerFilePath,
+		List<SubCommentResponse> subComments) {
+		this.commentId = commentId;
+		this.createdAt = createdAt;
+		this.content = content;
+		this.writerId = writerId;
+		this.writerNickname = writerNickname;
+		this.writerFilePath = writerFilePath;
+		this.subCommentCount = subComments.size();
+		this.subComments = subComments;
+	}
+
+	public static CommentResponse of(Comment comment, List<SubCommentResponse> subComments) {
+		User user = comment.getUser();
+		return CommentResponse.builder()
+			.commentId(comment.getId())
+			.createdAt(comment.getCreatedAt())
+			.content(comment.getContent())
+			.writerId(user.getId())
+			.writerNickname(user.getNickname())
+			.writerFilePath(user.getFilePath())
+			.subComments(subComments)
+			.build();
+	}
+}

--- a/src/main/java/com/codot/link/domains/post/dto/response/PostInfoResponse.java
+++ b/src/main/java/com/codot/link/domains/post/dto/response/PostInfoResponse.java
@@ -1,5 +1,7 @@
 package com.codot.link.domains.post.dto.response;
 
+import java.util.List;
+
 import com.codot.link.domains.post.domain.Post;
 import com.codot.link.domains.user.domain.User;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -19,19 +21,22 @@ public class PostInfoResponse extends PostResponse {
 	private Long postWriterId;
 	private String postWriterFilePath;
 	private String postWriterNickname;
-	// TODO: Comment 도메인 개발 완료 후 해당 게시물 Comment 정보도 포함하기
+	private Integer commentCount;
+	private List<CommentResponse> comments;
 
 	@Builder(access = AccessLevel.PRIVATE)
 	private PostInfoResponse(Long postId, String title, String content, Long postWriterId, String postWriterFilePath,
-		String postWriterNickname) {
+		String postWriterNickname, List<CommentResponse> comments) {
 		super(postId, title);
 		this.content = content;
 		this.postWriterId = postWriterId;
 		this.postWriterFilePath = postWriterFilePath;
 		this.postWriterNickname = postWriterNickname;
+		this.commentCount = comments.size();
+		this.comments = comments;
 	}
 
-	public static PostInfoResponse from(Post post) {
+	public static PostInfoResponse of(Post post, List<CommentResponse> comments) {
 		User user = post.getUser();
 		return PostInfoResponse.builder()
 			.postId(post.getId())
@@ -40,6 +45,7 @@ public class PostInfoResponse extends PostResponse {
 			.postWriterId(user.getId())
 			.postWriterFilePath(user.getFilePath())
 			.postWriterNickname(user.getNickname())
+			.comments(comments)
 			.build();
 	}
 }

--- a/src/main/java/com/codot/link/domains/post/dto/response/SubCommentResponse.java
+++ b/src/main/java/com/codot/link/domains/post/dto/response/SubCommentResponse.java
@@ -1,0 +1,50 @@
+package com.codot.link.domains.post.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.codot.link.domains.comment.domain.SubComment;
+import com.codot.link.domains.user.domain.User;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SubCommentResponse {
+
+	private Long subCommentId;
+	private LocalDateTime createdAt;
+	private String content;
+	private Long writerId;
+	private String writerNickname;
+	private String writerFilePath;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private SubCommentResponse(Long subCommentId, LocalDateTime createdAt, String content, Long writerId,
+		String writerNickname,
+		String writerFilePath) {
+		this.subCommentId = subCommentId;
+		this.createdAt = createdAt;
+		this.content = content;
+		this.writerId = writerId;
+		this.writerNickname = writerNickname;
+		this.writerFilePath = writerFilePath;
+	}
+
+	public static SubCommentResponse from(SubComment subComment) {
+		User user = subComment.getUser();
+		return SubCommentResponse.builder()
+			.subCommentId(subComment.getId())
+			.createdAt(subComment.getCreatedAt())
+			.content(subComment.getContent())
+			.writerId(user.getId())
+			.writerNickname(user.getNickname())
+			.writerFilePath(user.getFilePath())
+			.build();
+	}
+}


### PR DESCRIPTION
## 개요
- close #62 
## 작업사항
- 기존 엔티티 클래스 내부에 누락되었던 BaseEntity 상속 부분 추가
- CommentResponse, SubCommentResponse dto 생성
- PostInfoResponse dto 내부 구조 수정
- PostService POST2_INFO1 관련 메서드 내부 로직 수정 및 새로운 메서드 추가