### PR TITLE
feat: 토큰이 만료되거나 사용자가 로그아웃하면 Refresh Token 삭제하는 로직 개발 (#65)

### DIFF
--- a/src/main/java/com/codot/link/LinkApplication.java
+++ b/src/main/java/com/codot/link/LinkApplication.java
@@ -3,9 +3,11 @@ package com.codot.link;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@EnableScheduling
 @EnableJpaAuditing
+@SpringBootApplication
 public class LinkApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/codot/link/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/codot/link/common/config/WebSecurityConfig.java
@@ -37,7 +37,7 @@ public class WebSecurityConfig {
 		http
 			.authorizeHttpRequests(request -> request
 				.requestMatchers("/api/v1/**").authenticated()
-				.requestMatchers("/login").permitAll()
+				.requestMatchers("/login", "/users/logout").permitAll()
 				.requestMatchers(new AntPathRequestMatcher("/h2-console/**")).permitAll()
 				.anyRequest().authenticated());
 

--- a/src/main/java/com/codot/link/common/exception/model/ErrorCode.java
+++ b/src/main/java/com/codot/link/common/exception/model/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 	GROUP_USER_NOT_FOUND(NOT_FOUND, "존재하지 않는 그룹 가입 요청입니다."),
 	POST_NOT_FOUND(NOT_FOUND, "존재하지 않는 게시물입니다."),
 	COMMENT_NOT_FOUND(NOT_FOUND, "존재하지 않는 댓글입니다."),
+	REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "해당 사용자는 Refresh Token이 없습니다."),
 
 	// 409 CONFLICT
 	DUPLICATE_USER_NICKNAME(CONFLICT, "이미 존재하는 닉네임입니다."),
@@ -37,7 +38,8 @@ public enum ErrorCode {
 	NOT_POST_WRITER(CONFLICT, "해당 게시물의 작성자가 아닙니다."),
 	NOT_COMMENT_WRITER(CONFLICT, "해당 댓글의 작성자가 아닙니다."),
 	NOT_SUB_COMMENT_WRITER(CONFLICT, "해당 대댓글의 작성자가 아닙니다."),
-	REFRESHTOKEN_NOT_MATCH(CONFLICT, "Refresh Token이 일치하지 않습니다.");
+	REFRESH_TOKEN_EXPIRED(CONFLICT, "Refresh Token이 만료되었습니다."),
+	REFRESH_TOKEN_NOT_MATCH(CONFLICT, "Refresh Token이 일치하지 않습니다.");
 
 	private final String message;
 	private final int statusCode;

--- a/src/main/java/com/codot/link/common/scheduling/SchedulerService.java
+++ b/src/main/java/com/codot/link/common/scheduling/SchedulerService.java
@@ -1,0 +1,24 @@
+package com.codot.link.common.scheduling;
+
+import static java.time.LocalDateTime.*;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codot.link.domains.auth.repository.RefreshTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SchedulerService {
+
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	@Scheduled(cron = "0 0 * * * *")
+	protected void deleteExpiredRefreshToken() {
+		refreshTokenRepository.deleteAllByExpireAtBefore(now());
+	}
+}

--- a/src/main/java/com/codot/link/domains/auth/controller/TokenApiController.java
+++ b/src/main/java/com/codot/link/domains/auth/controller/TokenApiController.java
@@ -3,6 +3,7 @@ package com.codot.link.domains.auth.controller;
 import static org.springframework.http.HttpStatus.*;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,6 +39,14 @@ public class TokenApiController {
 		response.setHeader("access-token", token);
 		return ResponseEntity
 			.status(OK)
+			.build();
+	}
+
+	@DeleteMapping("/users/logout")
+	public ResponseEntity<Void> deleteJwt(@RequestHeader("user-id") Long userId) {
+		tokenService.deleteJwt(userId);
+		return ResponseEntity
+			.noContent()
 			.build();
 	}
 }

--- a/src/main/java/com/codot/link/domains/auth/domain/RefreshToken.java
+++ b/src/main/java/com/codot/link/domains/auth/domain/RefreshToken.java
@@ -1,5 +1,9 @@
 package com.codot.link.domains.auth.domain;
 
+import static java.time.LocalDateTime.*;
+
+import java.time.LocalDateTime;
+
 import com.codot.link.common.auditing.BaseEntity;
 import com.codot.link.domains.user.domain.User;
 
@@ -33,16 +37,21 @@ public class RefreshToken extends BaseEntity {
 	@Column(nullable = false)
 	private String token;
 
+	@Column(name = "expire_at", nullable = false)
+	private LocalDateTime expireAt;
+
 	@Builder(access = AccessLevel.PRIVATE)
-	private RefreshToken(User user, String token) {
+	private RefreshToken(User user, String token, LocalDateTime expireAt) {
 		this.user = user;
 		this.token = token;
+		this.expireAt = expireAt;
 	}
 
 	public static RefreshToken of(User user, String token) {
 		return RefreshToken.builder()
 			.user(user)
 			.token(token)
+			.expireAt(now().plusDays(7))
 			.build();
 	}
 }

--- a/src/main/java/com/codot/link/domains/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/codot/link/domains/auth/repository/RefreshTokenRepository.java
@@ -1,10 +1,17 @@
 package com.codot.link.domains.auth.repository;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.codot.link.domains.auth.domain.RefreshToken;
 import com.codot.link.domains.user.domain.User;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-	boolean existsByUserAndToken(User user, String token);
+	Optional<RefreshToken> findByUserAndToken(User user, String token);
+
+	void deleteAllByExpireAtBefore(LocalDateTime now);
+
+	Optional<RefreshToken> findByUser_Id(Long userId);
 }


### PR DESCRIPTION
## 개요
- close #65 
## 작업사항
- 토큰 재발급 시 해당 사용자의 refresh token이 만료되었다면 삭제하는 로직 추가
- SchedulerService 생성 후 매일 매 정각마다 만료된 refresh token 삭제하는 로직 추가
- logout 시 해당 사용자의 refresh token 삭제하는 로직 추가
