### PR TITLE
refactor: 누락된 Valid 어노테이션 추가 및 불필요한 어노테이션 삭제 (#72)

### DIFF
--- a/src/main/java/com/codot/link/domains/group/controller/GroupApiController.java
+++ b/src/main/java/com/codot/link/domains/group/controller/GroupApiController.java
@@ -73,7 +73,7 @@ public class GroupApiController {
 
 	@DeleteMapping("/{group_id}")
 	public ResponseEntity<Void> deleteGroup(@RequestHeader("user-id") Long userId,
-		@PathVariable("group_id") Long groupId, @RequestBody GroupDeleteRequest request) {
+		@PathVariable("group_id") Long groupId, @Valid @RequestBody GroupDeleteRequest request) {
 		groupService.deleteGroup(userId, groupId, request);
 		return ResponseEntity
 			.noContent()

--- a/src/main/java/com/codot/link/domains/post/controller/PostApiController.java
+++ b/src/main/java/com/codot/link/domains/post/controller/PostApiController.java
@@ -58,7 +58,7 @@ public class PostApiController {
 
 	@PatchMapping("/{post_id}")
 	public ResponseEntity<Void> modifyPost(@RequestHeader("user-id") Long userId, @PathVariable("post_id") Long postId,
-		@Valid @RequestBody PostModifyRequest request) {
+		@RequestBody PostModifyRequest request) {
 		postService.modifyPost(userId, postId, request);
 		return ResponseEntity
 			.noContent()


### PR DESCRIPTION
## 개요
- close #72 
## 작업사항
- deleteGroup 메서드에 누락됐던 Valid 어노테이션 추가
- modifyPost 메서드에 불필요한 Valid 어노테이션 제거
