### PR TITLE
chore: ResponseEntity 와일드 카드를 구체 타입으로 변경 (#75)

### DIFF
--- a/src/main/java/com/codot/link/domains/group/controller/GroupApiController.java
+++ b/src/main/java/com/codot/link/domains/group/controller/GroupApiController.java
@@ -81,7 +81,7 @@ public class GroupApiController {
 	}
 
 	@GetMapping("/request")
-	public ResponseEntity<?> groupRequestInfo(@RequestHeader("user-id") Long userId,
+	public ResponseEntity<GroupRequestInfoListResponse> groupRequestInfo(@RequestHeader("user-id") Long userId,
 		@Valid @RequestBody GroupRequestInfoRequest request) {
 		GroupRequestInfoListResponse response = groupUserService.groupRequestInfo(userId, request);
 		return ResponseEntity


### PR DESCRIPTION
## 개요
- close #75 
## 작업사항
- groupRequestInfo 메서드의 반환타입에 있던 비한정적 와일드카드를 구체 타입으로 변경