### PR TITLE
feat: 실제 푸시 알림을 보내는 로직 추가 (#79)

### DIFF
--- a/src/main/java/com/codot/link/common/exception/model/ErrorCode.java
+++ b/src/main/java/com/codot/link/common/exception/model/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 	POST_NOT_FOUND(NOT_FOUND, "존재하지 않는 게시물입니다."),
 	COMMENT_NOT_FOUND(NOT_FOUND, "존재하지 않는 댓글입니다."),
 	REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "해당 사용자는 Refresh Token이 없습니다."),
+	FCM_TOKEN_NOT_FOUND(NOT_FOUND, "해당 사용자는 Fcm Token이 없습니다."),
 
 	// 409 CONFLICT
 	DUPLICATE_USER_NICKNAME(CONFLICT, "이미 존재하는 닉네임입니다."),

--- a/src/main/java/com/codot/link/domains/fcm/FcmTokenRepository.java
+++ b/src/main/java/com/codot/link/domains/fcm/FcmTokenRepository.java
@@ -1,0 +1,21 @@
+package com.codot.link.domains.fcm;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.codot.link.domains.fcm.domain.FcmToken;
+import com.codot.link.domains.user.domain.User;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+	Optional<FcmToken> findByUser(User user);
+
+	@Query(value = "select * from fcm_token ft "
+		+ "join group_user gu on ft.user_id = gu.user_id "
+		+ "where gu.group_id = :groupId and gu.accepted = true", nativeQuery = true)
+	List<FcmToken> findAllByGroupId(@Param("groupId") Long groupId);
+}

--- a/src/main/java/com/codot/link/domains/fcm/dto/request/NotificationRequest.java
+++ b/src/main/java/com/codot/link/domains/fcm/dto/request/NotificationRequest.java
@@ -1,0 +1,27 @@
+package com.codot.link.domains.fcm.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationRequest {
+
+	private String title;
+	private String content;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private NotificationRequest(String title, String content) {
+		this.title = title;
+		this.content = content;
+	}
+
+	public static NotificationRequest of(String title, String content) {
+		return NotificationRequest.builder()
+			.title(title)
+			.content(content)
+			.build();
+	}
+}

--- a/src/main/java/com/codot/link/domains/fcm/service/FcmService.java
+++ b/src/main/java/com/codot/link/domains/fcm/service/FcmService.java
@@ -2,13 +2,6 @@ package com.codot.link.domains.fcm.service;
 
 import org.springframework.stereotype.Service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class FcmService {
-
-	private final FirebaseMessaging firebaseMessaging;
 }

--- a/src/main/java/com/codot/link/domains/fcm/service/usecase/NotifyGroupUserCase.java
+++ b/src/main/java/com/codot/link/domains/fcm/service/usecase/NotifyGroupUserCase.java
@@ -1,0 +1,32 @@
+package com.codot.link.domains.fcm.service.usecase;
+
+import org.springframework.stereotype.Component;
+
+import com.codot.link.domains.fcm.dto.request.NotificationRequest;
+import com.codot.link.domains.fcm.utils.FcmUtils;
+import com.codot.link.domains.group.domain.Group;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MulticastMessage;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotifyGroupUserCase {
+
+	private final FcmUtils fcmUtils;
+	private final FirebaseMessaging firebaseMessaging;
+
+	public void execute(NotificationRequest request, Group group) {
+		MulticastMessage message = fcmUtils.createPushMessageForGroupUsers(request, group);
+		try {
+			firebaseMessaging.sendEachForMulticast(message);
+			log.info("successfully sent push notification to all users in group id = {}", group.getId());
+		} catch (FirebaseMessagingException exception) {
+			log.info("failed to send push notification to users in group id = {}", group.getId());
+		}
+	}
+}

--- a/src/main/java/com/codot/link/domains/fcm/service/usecase/NotifySingleUserCase.java
+++ b/src/main/java/com/codot/link/domains/fcm/service/usecase/NotifySingleUserCase.java
@@ -1,0 +1,32 @@
+package com.codot.link.domains.fcm.service.usecase;
+
+import org.springframework.stereotype.Component;
+
+import com.codot.link.domains.fcm.dto.request.NotificationRequest;
+import com.codot.link.domains.fcm.utils.FcmUtils;
+import com.codot.link.domains.user.domain.User;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotifySingleUserCase {
+
+	private final FcmUtils fcmUtils;
+	private final FirebaseMessaging firebaseMessaging;
+
+	public void execute(NotificationRequest request, User user) {
+		Message message = fcmUtils.createPushMessageForSingleUser(request, user);
+		try {
+			firebaseMessaging.send(message);
+			log.info("successfully sent push notification to user id = {}", user.getId());
+		} catch (FirebaseMessagingException exception) {
+			log.info("failed to send push notification to user id = {}", user.getId());
+		}
+	}
+}

--- a/src/main/java/com/codot/link/domains/fcm/utils/FcmUtils.java
+++ b/src/main/java/com/codot/link/domains/fcm/utils/FcmUtils.java
@@ -1,0 +1,58 @@
+package com.codot.link.domains.fcm.utils;
+
+import static com.codot.link.common.exception.model.ErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.codot.link.common.exception.model.CustomException;
+import com.codot.link.domains.fcm.FcmTokenRepository;
+import com.codot.link.domains.fcm.domain.FcmToken;
+import com.codot.link.domains.fcm.dto.request.NotificationRequest;
+import com.codot.link.domains.group.domain.Group;
+import com.codot.link.domains.user.domain.User;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FcmUtils {
+
+	private final FcmTokenRepository fcmTokenRepository;
+
+	public Message createPushMessageForSingleUser(NotificationRequest request, User user) {
+		return Message.builder()
+			.setNotification(createNotificationFrom((request)))
+			.setToken(getFcmTokenByUser(user).getDeviceToken())
+			.build();
+	}
+
+	public MulticastMessage createPushMessageForGroupUsers(NotificationRequest request, Group group) {
+		return MulticastMessage.builder()
+			.setNotification(createNotificationFrom(request))
+			.addAllTokens(getDeviceTokensOfGroupUsers(group))
+			.build();
+	}
+
+	private Notification createNotificationFrom(NotificationRequest request) {
+		return Notification.builder()
+			.setTitle(request.getTitle())
+			.setBody(request.getContent())
+			.build();
+	}
+
+	private FcmToken getFcmTokenByUser(User user) {
+		return fcmTokenRepository.findByUser(user)
+			.orElseThrow(() -> CustomException.from(FCM_TOKEN_NOT_FOUND));
+	}
+
+	private List<String> getDeviceTokensOfGroupUsers(Group group) {
+		return fcmTokenRepository.findAllByGroupId(group.getId()).stream()
+			.map(FcmToken::getDeviceToken)
+			.toList();
+	}
+}


### PR DESCRIPTION
## 개요
- close #79 
## 작업사항
- '단일 유저 푸시 알림 전송' use case에 해당하는 NotifySingleUserCase 생성
- '그룹 내 모든 유저 푸시 알림 전송' use case에 해당하는 NotifyGroupUserCase 생성
- Message, MulticastMessage 생성하는 FcmUtils 생성
- FcmToken 조회하는 조회 메서드(네이티브) FcmTokenRepository에 추가
- Message 생성 시 필요한 데이터를 담아서 넘길 수 있는 NotificationRequest dto 생성