### PR TITLE
refactor: FcmToken 도메인 클래스가 BaseEntity 상속하도록 수정 (#82)

### DIFF
--- a/src/main/java/com/codot/link/domains/fcm/domain/FcmToken.java
+++ b/src/main/java/com/codot/link/domains/fcm/domain/FcmToken.java
@@ -1,5 +1,6 @@
 package com.codot.link.domains.fcm.domain;
 
+import com.codot.link.common.auditing.BaseEntity;
 import com.codot.link.domains.user.domain.User;
 
 import jakarta.persistence.Column;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FcmToken {
+public class FcmToken extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 개요
- close #82 
## 작업사항
- FcmToken BaseEntity 상속하는 코드 포함하도록 수정