### PR TITLE
feat: User 엔티티 삭제 시 연관된 모든 엔티티를 같이 삭제하는 로직 추가 (#80)

### DIFF
--- a/src/main/java/com/codot/link/domains/auth/domain/LoginRecord.java
+++ b/src/main/java/com/codot/link/domains/auth/domain/LoginRecord.java
@@ -11,7 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,7 +27,7 @@ public class LoginRecord {
 	@Column(name = "login_record_id")
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 

--- a/src/main/java/com/codot/link/domains/auth/domain/RefreshToken.java
+++ b/src/main/java/com/codot/link/domains/auth/domain/RefreshToken.java
@@ -14,7 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,7 +30,7 @@ public class RefreshToken extends BaseEntity {
 	@Column(name = "refresh_token_id")
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 

--- a/src/main/java/com/codot/link/domains/auth/repository/LoginRecordRepository.java
+++ b/src/main/java/com/codot/link/domains/auth/repository/LoginRecordRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.codot.link.domains.auth.domain.LoginRecord;
 import com.codot.link.domains.auth.domain.Provider;
+import com.codot.link.domains.user.domain.User;
 
 public interface LoginRecordRepository extends JpaRepository<LoginRecord, Long> {
 
 	Optional<LoginRecord> findByOauthIdAndProvider(String oauthId, Provider provider);
+
+	void deleteByUser(User user);
 }

--- a/src/main/java/com/codot/link/domains/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/codot/link/domains/auth/repository/RefreshTokenRepository.java
@@ -14,4 +14,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 	void deleteAllByExpireAtBefore(LocalDateTime now);
 
 	Optional<RefreshToken> findByUser_Id(Long userId);
+
+	void deleteByUser(User user);
 }

--- a/src/main/java/com/codot/link/domains/fcm/FcmTokenRepository.java
+++ b/src/main/java/com/codot/link/domains/fcm/FcmTokenRepository.java
@@ -18,4 +18,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 		+ "join group_user gu on ft.user_id = gu.user_id "
 		+ "where gu.group_id = :groupId and gu.accepted = true", nativeQuery = true)
 	List<FcmToken> findAllByGroupId(@Param("groupId") Long groupId);
+
+	void deleteByUser(User user);
 }

--- a/src/main/java/com/codot/link/domains/group/domain/Group.java
+++ b/src/main/java/com/codot/link/domains/group/domain/Group.java
@@ -1,14 +1,19 @@
 package com.codot.link.domains.group.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.codot.link.common.auditing.BaseEntity;
 import com.codot.link.domains.group.dto.request.GroupCreateRequest;
 import com.codot.link.domains.group.dto.request.GroupModifyRequest;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -31,6 +36,9 @@ public class Group extends BaseEntity {
 
 	@Column(nullable = false)
 	private String description;
+
+	@OneToMany(mappedBy = "group", cascade = CascadeType.REMOVE)
+	private List<GroupUser> groupUsers = new ArrayList<>();
 
 	@Builder(access = AccessLevel.PRIVATE)
 	private Group(String name, String description) {

--- a/src/main/java/com/codot/link/domains/group/repository/GroupRepository.java
+++ b/src/main/java/com/codot/link/domains/group/repository/GroupRepository.java
@@ -43,4 +43,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 		+ "where g.name REGEXP :regex "
 		+ "or g.description REGEXP :regex", nativeQuery = true)
 	List<Group> findAllBySearchTextRegex(@Param("regex") String regex);
+
+	@Query(value = "select * from groups g "
+		+ "where exists (select 1 from group_user gu where gu.user_id = :userId and gu.group_id = gu.group_id and gu.role = 'HOST')", nativeQuery = true)
+	List<Group> findAllByHostUser(@Param("userId") Long userId);
 }

--- a/src/main/java/com/codot/link/domains/link/repository/LinkRepository.java
+++ b/src/main/java/com/codot/link/domains/link/repository/LinkRepository.java
@@ -33,4 +33,6 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 			+ "order by random() "
 			+ "limit 5", nativeQuery = true)
 	List<Link> findTwoHops(@Param("userId") Long userId);
+
+	void deleteAllByFromOrTo(User from, User to);
 }

--- a/src/main/java/com/codot/link/domains/message/repository/MessageRepository.java
+++ b/src/main/java/com/codot/link/domains/message/repository/MessageRepository.java
@@ -5,7 +5,10 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.codot.link.domains.message.domain.Message;
+import com.codot.link.domains.user.domain.User;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
 	List<Message> findAllByReceiver_Id(Long receiverId);
+
+	void deleteAllBySenderOrReceiver(User sender, User receiver);
 }

--- a/src/main/java/com/codot/link/domains/post/repository/PostRepository.java
+++ b/src/main/java/com/codot/link/domains/post/repository/PostRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.codot.link.domains.post.domain.Post;
+import com.codot.link.domains.user.domain.User;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
@@ -20,4 +21,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findAllByGroup_Id(Long groupId);
 
 	Optional<Post> findByIdAndUser_Id(Long postId, Long userId);
+
+	void deleteAllByUser(User user);
 }


### PR DESCRIPTION
## 개요
- close #80 
## 작업사항
User 삭제 시 관련된 
- token
- Link
- Message
- Post
- Group
- GroupUser
- Comment
- SubComment
- LoginRecord
를 제거하는 로직 추가